### PR TITLE
Change currency code used from RMB to CNY

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Four Thunderbolt 3 ports
 
 
-RMB 25,135
+CNY 25,135
 
 ## Must Have
 


### PR DESCRIPTION
RMB is, despite what most people in China believe, NOT the currency code listed in ISO 4217 that represents Chinese Yuan. Please use CNY not only in this great write-up, but all your future documents, too. Thanks.